### PR TITLE
Disabled prop fading for now + changelog update

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,43 @@
-﻿
+﻿----------------------------------------------------------------------------------
+
+v1.3.3
+- Fixed a bug that caused AAText to not render properly at small resolutions.
+- Moved audio settings to their own location in options.ini.
+- Finally fixed 860-1's ambience not playing inside the forest.
+
+- Fixed the Tesla gate activating when the player is above the room.
+
+- Removed room1archive1074.
+
+- Added the ability for the night vision goggles to somewhat supress 895's effects.
+
+- Fixed a bug that prevented swapping between night vision goggle variants.
+
+- Fixed night vision goggles not working when secondary lighting is off.
+
+- Fixed the reset096 console command so it will work for not just lockroom096.
+
+- Fixed 106's spawn in 895's chamber
+- Fixed bugs relating to the "Ulgrin shooting the player" event in the post-breach intro.
+
+- The propaganda leaflet disappears from the player's inventory when the 1123 event finishes.
+
+- Fixed SCP-079's broadcasts triggering during SCP-1123's event.
+- Fixed an oversight that allowed the player to leave 1123's chamber before the event completed.
+- Fixed 682 roar playing in 1499, 860-1, and 1123's events.
+
+- Fixed 294's injuries + bloodloss parameters not having an effect
+.
+- Fixed 294's dispensing sounds.
+- Fixed SCP-1123's pickup sound (when SCP-714 is equipped).
+
+- The player dies when using SCP-1123 outside of its chamber.
+- Fixed a bug that caused secondary lighting to affect Gate A and B.
+- Fixed SCP-895's monitor freezing when the coffin camera was disabled.
+- Added tooltips to the option menu.
+- Added texture quality and particle amount settings.
+- Updated hand icon
+
 ----------------------------------------------------------------------------------
 
 v1.3.2

--- a/Main.bb
+++ b/Main.bb
@@ -1688,7 +1688,7 @@ Select ResolutionDetails
 End Select
 
 Global ParticleAmount% = GetINIInt(OptionFile,"options","particle amount")
-Global PropFading% = GetINIInt(OptionFile,"options","prop fading")
+Global PropFading% = False ;GetINIInt(OptionFile,"options","prop fading")
 ;[End Block]
 
 ;-----------------------------------------  Images ----------------------------------------------------------
@@ -5988,12 +5988,12 @@ Function DrawMenu()
 					
 					y=y+50*MenuScale
 					
-					Color 255,255,255
-					AAText(x, y, "Enable prop fading:")
-					PropFading = DrawTick(x + 270 * MenuScale, y + MenuScale, PropFading)
-					If MouseOn(x+270*MenuScale,y+MenuScale,20*MenuScale,20*MenuScale) And OnSliderID=0
-						DrawOptionsTooltip(tx,ty,tw,th+100*MenuScale,"propfading")
-					EndIf
+					;Color 255,255,255
+					;AAText(x, y, "Enable prop fading:")
+					;PropFading = DrawTick(x + 270 * MenuScale, y + MenuScale, PropFading)
+					;If MouseOn(x+270*MenuScale,y+MenuScale,20*MenuScale,20*MenuScale) And OnSliderID=0
+					;	DrawOptionsTooltip(tx,ty,tw,th+100*MenuScale,"propfading")
+					;EndIf
 					;[End Block]
 				Case 2 ;Audio
 					AASetFont Font1


### PR DESCRIPTION
The way it's currently implemented may cause props to disappear from the view (it's possible to see further than 8 units in some rooms) and the performance improvement is negligible compared to the cost of the distance checks